### PR TITLE
Fix duplicate import in create_sdk.py

### DIFF
--- a/src/app/user_commands/create_sdk.py
+++ b/src/app/user_commands/create_sdk.py
@@ -31,7 +31,6 @@ import tomllib
 import shutil
 from pathlib import Path
 from typing import List, Dict, Optional
-import tomllib
 
 from rich.console import Console
 from rich.panel import Panel


### PR DESCRIPTION
## Summary
- remove the duplicated `tomllib` import in `create_sdk.py`

## Testing
- `make lint` *(fails: flake8 not installed)*
- `make test` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68534ba9a704832fa8bbce3d1603300b