### PR TITLE
Fix SDK generation without package-name flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "psycopg2-binary",
     "rich>=14.0.0",
     "colorama",
+    "PyYAML",
 ]
 
 [project.scripts]

--- a/src/app/user_commands/create_sdk.py
+++ b/src/app/user_commands/create_sdk.py
@@ -29,6 +29,7 @@ import json
 import re
 import tomllib
 import shutil
+import yaml
 from pathlib import Path
 from typing import List, Dict, Optional
 
@@ -86,13 +87,26 @@ def sanitize_sdk_name(name: str) -> str:
 def build_command(spec: Path, sdk_name: str, package_name: str) -> List[str]:
     dest = OUTPUT_BASE_DIR / sdk_name
     dest.mkdir(parents=True, exist_ok=True)
+
+    cfg_path = dest / ".openapi-config.yml"
+    cfg_data = {
+        "project_name_override": package_name,
+        "package_name_override": package_name,
+    }
+    cfg_path.write_text(yaml.safe_dump(cfg_data), encoding="utf-8")
+
     return [
-        "openapi-python-client", "generate",
-        "--path", str(spec),
-        "--output-path", str(dest),
-        "--meta", "poetry",
+        "openapi-python-client",
+        "generate",
+        "--path",
+        str(spec),
+        "--output-path",
+        str(dest),
+        "--meta",
+        "poetry",
         "--overwrite",
-        "--package-name", package_name,
+        "--config",
+        str(cfg_path),
     ]
 
 

--- a/tests/test_create_sdk.py
+++ b/tests/test_create_sdk.py
@@ -74,14 +74,22 @@ def test_build_command_creates_directory(temp_output_dir, tmp_path, create_sdk_m
     spec.write_text("openapi: 3.0")
     pkg_name = create_sdk_module.sanitize_sdk_name("mysdk")
     cmd = create_sdk_module.build_command(spec, "mysdk", pkg_name)
-    assert temp_output_dir.joinpath("mysdk").exists()
+    dest = temp_output_dir / "mysdk"
+    cfg = dest / ".openapi-config.yml"
+    assert dest.exists()
+    assert cfg.exists()
     assert cmd == [
-        "openapi-python-client", "generate",
-        "--path", str(spec),
-        "--output-path", str(temp_output_dir / "mysdk"),
-        "--meta", "poetry",
+        "openapi-python-client",
+        "generate",
+        "--path",
+        str(spec),
+        "--output-path",
+        str(dest),
+        "--meta",
+        "poetry",
         "--overwrite",
-        "--package-name", pkg_name,
+        "--config",
+        str(cfg),
     ]
 
 


### PR DESCRIPTION
## Summary
- update create_sdk to use openapi-python-client config file
- expect YAML config in tests
- include PyYAML dependency for CLI tooling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685353281d64832faba56337636acf73