### PR TITLE
Fix Hyperfabric client defaults

### DIFF
--- a/src/app/llm/platform_clients/nexus_hyperfabric_client.py
+++ b/src/app/llm/platform_clients/nexus_hyperfabric_client.py
@@ -1,11 +1,19 @@
 # app/llm/platform_clients/nexus_hyperfabric_client.py
 # Auto‑generated – DO NOT EDIT
 import nexus_hyperfabric as _sdk
+import os
 
 class Nexus_hyperfabricClient:
     """Thin wrapper around `AuthenticatedClient` with fuzzy attribute lookup."""
 
     def __init__(self, **kwargs):
+        base_url = os.getenv('NEXUS_HYPERFABRIC_BASE_URL')
+        token = os.getenv('NEXUS_HYPERFABRIC_BEARER_TOKEN')
+        if not base_url or not token:
+            raise ValueError('Missing NEXUS_HYPERFABRIC_BASE_URL or NEXUS_HYPERFABRIC_BEARER_TOKEN')
+        kwargs.setdefault('base_url', base_url)
+        kwargs.setdefault('token', token)
+
         self._sdk = _sdk.AuthenticatedClient(**kwargs)
 
     def __getattr__(self, item):

--- a/src/scripts/platform_scaffolder.py
+++ b/src/scripts/platform_scaffolder.py
@@ -289,7 +289,21 @@ def _emit_client_stub(platform: str, sdk_module: str) -> None:
             raise AttributeError(f"{self.__class__.__name__} has no attribute {item!r}")
     """).splitlines()
 
-    if platform.lower() != "meraki":
+    if platform.lower() == "meraki":
+        pass
+    elif platform.lower() == "nexus_hyperfabric":
+        extra_imports.append("import os")
+        extra_init.extend([
+            "base_url = os.getenv('NEXUS_HYPERFABRIC_BASE_URL')",
+            "token = os.getenv('NEXUS_HYPERFABRIC_BEARER_TOKEN')",
+            "if not base_url or not token:",
+            "    raise ValueError('Missing NEXUS_HYPERFABRIC_BASE_URL or NEXUS_HYPERFABRIC_BEARER_TOKEN')",
+            "kwargs.setdefault('base_url', base_url)",
+            "kwargs.setdefault('token', token)",
+            "",
+        ])
+        extra_methods.extend(['    ' + line if line else '' for line in default_getattr])
+    else:
         extra_methods.extend(['    ' + line if line else '' for line in default_getattr])
 
      # ── assemble file ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add env var defaults for Nexus Hyperfabric client
- teach platform scaffolder to inject these defaults

## Testing
- `make lint` *(fails: E501 line too long)*
- `make test` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68535fd62a48832fafb3c310b032eb43