### PR TITLE
Fix SDK version and sanitize generation

### DIFF
--- a/src/db_scripts/output_sdk/nexus_hyperfabric/pyproject.toml
+++ b/src/db_scripts/output_sdk/nexus_hyperfabric/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nexus_hyperfabric"
-version = "1.0.6-Rev.2025-03-11.13103"
+version = "1.0.6.post2025.03.11.13103"
 description = "A client library for accessing Cisco Nexus Hyperfabric REST API"
 authors = []
 readme = "README.md"


### PR DESCRIPTION
## Summary
- sanitize generated SDK versions to comply with PEP 440
- patch existing Nexus Hyperfabric SDK with a valid version string

## Testing
- `PYTHONPATH=$PWD/src pytest tests --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_685364bfb2dc832f9d3020cc6d9be251