### PR TITLE
Update OpenAPI version string

### DIFF
--- a/src/app/llm/openapi_specs/full_nexus_hyperfabric.json
+++ b/src/app/llm/openapi_specs/full_nexus_hyperfabric.json
@@ -13,7 +13,7 @@
     },
     "termsOfService":"https://www.cisco.com/c/dam/en_us/about/doing_business/legal/Cisco_General_Terms.pdf",
     "title":"Cisco Nexus Hyperfabric REST API",
-    "version":"1.0.6-Rev.2025-03-11.13103"
+    "version":"1.0.6.post2025.03.11.13103"
   },
   "paths":{
     "/bearerTokens":{

--- a/src/app/llm/openapi_specs/nexus_hyperfabric.json
+++ b/src/app/llm/openapi_specs/nexus_hyperfabric.json
@@ -13,7 +13,7 @@
     },
     "termsOfService":"https://www.cisco.com/c/dam/en_us/about/doing_business/legal/Cisco_General_Terms.pdf",
     "title":"Cisco Nexus Hyperfabric REST API",
-    "version":"1.0.6-Rev.2025-03-11.13103"
+    "version":"1.0.6.post2025.03.11.13103"
   },
   "paths":{
     "/bearerTokens":{

--- a/src/source_open_api/cisco_nexus_hyperfabric_rest_api_1_0_6_rev_2025_03_11_13103.json
+++ b/src/source_open_api/cisco_nexus_hyperfabric_rest_api_1_0_6_rev_2025_03_11_13103.json
@@ -13,7 +13,7 @@
   },
   "termsOfService": "https://www.cisco.com/c/dam/en_us/about/doing_business/legal/Cisco_General_Terms.pdf",
   "title": "Cisco Nexus Hyperfabric REST API",
-  "version": "1.0.6-Rev.2025-03-11.13103"
+  "version": "1.0.6.post2025.03.11.13103"
  },
  "paths": {
   "/bearerTokens": {


### PR DESCRIPTION
## Summary
- change Nexus Hyperfabric OpenAPI version to PEP 440 format
- regenerate SDK (fails: `openapi-python-client` missing)

## Testing
- `make lint` *(fails: E501 etc.)*
- `make test` *(fails: ModuleNotFoundError: No module named 'app')*
- `python src/db_scripts/generate_openapi_sdks.py` *(fails: No such file or directory: 'openapi-python-client')*

------
https://chatgpt.com/codex/tasks/task_e_68536af9de14832fba234b19e35d6301