### PR TITLE
Add FastAPI and Uvicorn dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ source .venv/bin/activate
 cp env.example .env
 # Then edit .env to configure platforms, credentials, backends, etc.
 
-# 4. Install required modules
+# 4. Install required modules (includes FastAPI and Uvicorn)
 pip install -r requirements.txt
 pip install -e .
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,7 @@ structlog==25.3.0
 sumy==0.11.0
 transformers==4.51.3
 yake==0.4.8
+
+# Web server dependencies
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- include `fastapi` and `uvicorn` in `requirements.txt`
- mention these packages in README install steps

## Testing
- `make lint` *(fails: flake8 not installed)*
- `make test` *(fails: ModuleNotFoundError: No module named 'app')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement aiohttp==3.11.11)*

------
https://chatgpt.com/codex/tasks/task_e_685377f313a4832fb18add357229d38b