### PR TITLE
Fix router import guards

### DIFF
--- a/src/app/routers/__init__.py
+++ b/src/app/routers/__init__.py
@@ -30,11 +30,6 @@ try:
 except ImportError:
     chat_router = None
 try:
-    from .chat_routes import router as chat_router
-    __all__.append("chat_routes")
-except ImportError:
-    chat_router = None
-try:
     from .meraki_routes import router as meraki_router
     __all__.append("meraki_routes")
 except ImportError:
@@ -66,5 +61,6 @@ except ImportError:
     sdwan_mngr_router = None
 try:
     from .nexus_hyperfabric_routes import router as nexus_hyperfabric_router
+    __all__.append("nexus_hyperfabric_routes")
 except ImportError:
-    pass
+    nexus_hyperfabric_router = None


### PR DESCRIPTION
## Summary
- fix duplicate chat_routes block
- guard nexus_hyperfabric_routes import

## Testing
- `PYTHONPATH=src python - <<'EOF'
import app.routers as r
print('ALL', r.__all__)
print('nexus router is None:', r.nexus_hyperfabric_router is None)
EOF`
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685377f00bdc832fb7694c4ab065e8cb