### PR TITLE
Replace example.env references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ all_files-*.txt
 
 # ─── Local config / secrets ───────────────────────────────────────────────────
 *.env
-# keep example.env in source; only ignore real “.env”
+# keep env.sample in source; only ignore real “.env”
 
 # ─── Your generated listings ──────────────────────────────────────────────────
 ai-building-agent-*.txt

--- a/docs/example_environment_variables_guide.MD
+++ b/docs/example_environment_variables_guide.MD
@@ -32,7 +32,7 @@
 
 ## 1. Global block
 
-| Variable                      | Purpose                                        | Default in `example.env`                  |
+| Variable                      | Purpose                                        | Default in `env.sample`                  |
 | ----------------------------- | ---------------------------------------------- | ----------------------------------------- |
 | `DEBUG_MODE`                  | Verbose logging toggle                         | `false`                                   |
 | `ENABLE_*`                    | One flag per Cisco SaaS (Meraki, Spaces, etc.) | all **false** except `ENABLE_MERAKI=true` |
@@ -160,8 +160,8 @@ No extra env-vars needed.
 ### Quick start
 
 ```bash
-cp example.env .env
-# fill in your Azure + Cisco keys
+# Copy the sample and edit `.env` with your Azure and Cisco keys
+cp env.sample .env
 
 # build indexes
 python -m scripts.process_docs      # FASTAPI layer

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -29,10 +29,11 @@ cd suite-cisco-ai-building-blocks
 
 ## 3. Set Up Environment Variables
 
-Copy and edit the example environment file:
+Copy and edit the environment sample file:
 
 ```bash
-cp example.env .env
+# Copy the sample and edit `.env` for your setup
+cp env.sample .env
 # Edit .env to configure VECTOR_BACKEND, FEATURE flags, credentials, etc.
 ```
 


### PR DESCRIPTION
## Summary
- update instructions to reference `env.sample` instead of `example.env`
- adjust .gitignore comment accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685377e64bd4832fadc9ebd0501d5d68