### PR TITLE
Update telemetry instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,15 @@ create-domain-demo-index
 create-events-index
 create-platform-index
 
-# 6. Start the AI Agent (FastAPI server)
-uvicorn app.main:app --reload
+# 6. Launch the interactive menu and enable telemetry
+menu
+# Then select option **3 – Start Telemetry Stack** to bring up Grafana, Tempo, and Prometheus.
+# Next choose option **1 – Start Cisco Platform AI**. When prompted,
+# answer `y` to **Enable OpenTelemetry export? (y/n)**.
 
 # 7. Open browser UI
 http://127.0.0.1:8000/static/
+# When finished, use menu option **4 – Stop Telemetry Stack** to tear it down.
 ```
 
 ---


### PR DESCRIPTION
## Summary
- describe how to start the telemetry stack with the CLI menu
- show how to enable OpenTelemetry when starting the FastAPI app
- mention how to shut down the telemetry stack

## Testing
- `pytest -q` *(fails: AttributeError: module 'app.user_commands.create_sdk' has no attribute)*
- `make lint` *(fails: flake8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546c6ecdb8832fae1376e57e27b476